### PR TITLE
Bump spotbugs checks to rank 20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,7 +200,7 @@
           <effort>Max</effort>
           <failOnError>true</failOnError>
           <includeTests>true</includeTests>
-          <maxRank>17</maxRank>
+          <maxRank>20</maxRank>
           <jvmArgs>-Dcom.overstock.findbugs.ignore=com.google.common.util.concurrent.RateLimiter,com.google.common.hash.Hasher,com.google.common.hash.HashCode,com.google.common.hash.HashFunction,com.google.common.hash.Hashing,com.google.common.cache.Cache,com.google.common.io.CountingOutputStream,com.google.common.io.ByteStreams,com.google.common.cache.LoadingCache,com.google.common.base.Stopwatch,com.google.common.cache.RemovalNotification,com.google.common.util.concurrent.Uninterruptibles,com.google.common.reflect.ClassPath,com.google.common.reflect.ClassPath$ClassInfo,com.google.common.base.Throwables,com.google.common.collect.Iterators</jvmArgs>
           <plugins combine.children="append">
             <plugin>

--- a/src/build/ci/spotbugs-exclude.xml
+++ b/src/build/ci/spotbugs-exclude.xml
@@ -21,6 +21,6 @@
 -->
 <FindBugsFilter>
 <Match>
-  <Class name="~.*\.jmh_generated\..*" />
+  <Class name="~.*[.]jmh_generated[.].*" />
 </Match>
 </FindBugsFilter>

--- a/src/main/java/org/apache/accumulo/access/AeNode.java
+++ b/src/main/java/org/apache/accumulo/access/AeNode.java
@@ -41,11 +41,7 @@ abstract class AeNode implements Comparable<AeNode> {
 
   @Override
   public boolean equals(Object o) {
-    if (o instanceof AeNode) {
-      return compareTo((AeNode) o) == 0;
-    }
-
-    return false;
+    return o instanceof AeNode && compareTo((AeNode) o) == 0;
   }
 
   @Override

--- a/src/main/java/org/apache/accumulo/access/CachingAccessEvaluator.java
+++ b/src/main/java/org/apache/accumulo/access/CachingAccessEvaluator.java
@@ -34,6 +34,8 @@ class CachingAccessEvaluator implements AccessEvaluator {
     }
     this.accessEvaluator = accessEvaluator;
     this.cache = new LinkedHashMap<>(cacheSize, 0.75f, true) {
+      private static final long serialVersionUID = 1L;
+
       @Override
       public boolean removeEldestEntry(Map.Entry<String,Boolean> entry) {
         return size() > cacheSize;

--- a/src/test/java/org/apache/accumulo/access/AccessEvaluatorTest.java
+++ b/src/test/java/org/apache/accumulo/access/AccessEvaluatorTest.java
@@ -82,6 +82,7 @@ public class AccessEvaluatorTest {
     assertFalse(testData.isEmpty());
 
     for (var testSet : testData) {
+      System.out.println("runTestCases for " + testSet.description);
       AccessEvaluator evaluator;
       assertTrue(testSet.auths.length >= 1);
       if (testSet.auths.length == 1) {

--- a/src/test/java/org/apache/accumulo/access/AccessExpressionBenchmark.java
+++ b/src/test/java/org/apache/accumulo/access/AccessExpressionBenchmark.java
@@ -118,8 +118,8 @@ public class AccessExpressionBenchmark {
       return allTestExpressionsStr;
     }
 
-    public List<EvaluatorTests> getEvaluatorTests() {
-      return Collections.unmodifiableList(evaluatorTests);
+    List<EvaluatorTests> getEvaluatorTests() {
+      return evaluatorTests;
     }
 
   }

--- a/src/test/java/org/apache/accumulo/access/AccessExpressionBenchmark.java
+++ b/src/test/java/org/apache/accumulo/access/AccessExpressionBenchmark.java
@@ -22,7 +22,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;

--- a/src/test/java/org/apache/accumulo/access/AccessExpressionBenchmark.java
+++ b/src/test/java/org/apache/accumulo/access/AccessExpressionBenchmark.java
@@ -22,6 +22,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -118,7 +119,7 @@ public class AccessExpressionBenchmark {
     }
 
     public List<EvaluatorTests> getEvaluatorTests() {
-      return List.copyOf(evaluatorTests);
+      return Collections.unmodifiableList(evaluatorTests);
     }
 
   }

--- a/src/test/java/org/apache/accumulo/access/AccessExpressionBenchmark.java
+++ b/src/test/java/org/apache/accumulo/access/AccessExpressionBenchmark.java
@@ -117,8 +117,8 @@ public class AccessExpressionBenchmark {
       return allTestExpressionsStr;
     }
 
-    public ArrayList<EvaluatorTests> getEvaluatorTests() {
-      return evaluatorTests;
+    public List<EvaluatorTests> getEvaluatorTests() {
+      return List.copyOf(evaluatorTests);
     }
 
   }


### PR DESCRIPTION
Bump spotbugs aggressiveness to rank 20 and fix 3 new issues:
* Add missing serialVersionUID field for anonymous subclass of serializable class
* Make use of description field from test data to avoid spotbugs error about unused field (the alternative was to suppress it; I thought printing it was better, since the description is there for our convenience)
* Internal mutable type leaking through benchmark class's API

Also include trivial fixes from code review in #22:
* Simplified .equals to one line
* Use character class for matching on literal dot to avoid escape confusion with backslash