### PR TITLE
Replace method calls with original checks using constants

### DIFF
--- a/src/main/java/org/apache/accumulo/access/ByteUtils.java
+++ b/src/main/java/org/apache/accumulo/access/ByteUtils.java
@@ -31,28 +31,4 @@ public final class ByteUtils {
   private ByteUtils() {
     // private constructor to prevent instantiation
   }
-
-  public static boolean isQuoteSymbol(byte b) {
-    return b == QUOTE;
-  }
-
-  public static boolean isBackslashSymbol(byte b) {
-    return b == BACKSLASH;
-  }
-
-  public static boolean isQuoteOrSlash(byte b) {
-    return isQuoteSymbol(b) || isBackslashSymbol(b);
-  }
-
-  public static boolean isAndOperator(byte b) {
-    return b == AND_OPERATOR;
-  }
-
-  public static boolean isOrOperator(byte b) {
-    return b == OR_OPERATOR;
-  }
-
-  public static boolean isAndOrOperator(byte b) {
-    return isAndOperator(b) || isOrOperator(b);
-  }
 }

--- a/src/main/java/org/apache/accumulo/access/Parser.java
+++ b/src/main/java/org/apache/accumulo/access/Parser.java
@@ -18,7 +18,8 @@
  */
 package org.apache.accumulo.access;
 
-import static org.apache.accumulo.access.ByteUtils.isAndOrOperator;
+import static org.apache.accumulo.access.ByteUtils.AND_OPERATOR;
+import static org.apache.accumulo.access.ByteUtils.OR_OPERATOR;
 
 import java.util.ArrayList;
 
@@ -52,7 +53,8 @@ final class Parser {
 
     AeNode first = parseParenExpressionOrAuthorization(tokenizer);
 
-    if (tokenizer.hasNext() && isAndOrOperator(tokenizer.peek())) {
+    if (tokenizer.hasNext()
+        && (tokenizer.peek() == AND_OPERATOR || tokenizer.peek() == OR_OPERATOR)) {
       var nodes = new ArrayList<AeNode>();
       nodes.add(first);
 
@@ -65,7 +67,8 @@ final class Parser {
 
       } while (tokenizer.hasNext() && tokenizer.peek() == operator);
 
-      if (tokenizer.hasNext() && isAndOrOperator(tokenizer.peek())) {
+      if (tokenizer.hasNext()
+          && (tokenizer.peek() == OR_OPERATOR || tokenizer.peek() == AND_OPERATOR)) {
         // A case of mixed operators, lets give a clear error message
         tokenizer.error("Cannot mix '|' and '&'");
       }

--- a/src/main/java/org/apache/accumulo/access/Tokenizer.java
+++ b/src/main/java/org/apache/accumulo/access/Tokenizer.java
@@ -19,9 +19,8 @@
 package org.apache.accumulo.access;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.accumulo.access.ByteUtils.isBackslashSymbol;
-import static org.apache.accumulo.access.ByteUtils.isQuoteOrSlash;
-import static org.apache.accumulo.access.ByteUtils.isQuoteSymbol;
+import static org.apache.accumulo.access.ByteUtils.BACKSLASH;
+import static org.apache.accumulo.access.ByteUtils.QUOTE;
 
 import java.util.stream.IntStream;
 
@@ -97,13 +96,14 @@ final class Tokenizer {
   }
 
   AuthorizationToken nextAuthorization() {
-    if (isQuoteSymbol(expression[index])) {
+    if (expression[index] == QUOTE) {
       int start = ++index;
 
-      while (index < expression.length && !isQuoteSymbol(expression[index])) {
-        if (isBackslashSymbol(expression[index])) {
+      while (index < expression.length && expression[index] != QUOTE) {
+        if (expression[index] == BACKSLASH) {
           index++;
-          if (index == expression.length || !isQuoteOrSlash(expression[index])) {
+          if (index == expression.length
+              || (expression[index] != BACKSLASH && expression[index] != QUOTE)) {
             error("Invalid escaping within quotes", index - 1);
           }
         }


### PR DESCRIPTION
I removed the methods from ByteUtils and reverted the places where the methods were called back to their original logic, but retained the use of the ByteUtils static variables. This yielded no significant performance difference. I re-ran the benchmarks on main before #27 was merged, the HEAD of main, and this branch. I ran `mvn clean verify` on each branch and ran the benchmark using the command: 
```
taskset -c 1 mvn exec:exec -Dexec.executable="java" -Dexec.classpathScope=test -Dexec.args="-classpath %classpath org.apache.accumulo.access.AccessExpressionBenchmark"
```

Here are the results:
```
main @c959026c8631da8691764b3f20a9148b84bafc99:
AccessExpressionBenchmark.measureBytesParsing          thrpt   12  12.665 ± 0.225  ops/us
AccessExpressionBenchmark.measureEvaluation            thrpt   12  16.663 ± 0.441  ops/us
AccessExpressionBenchmark.measureEvaluationAndParsing  thrpt   12   8.435 ± 0.117  ops/us
AccessExpressionBenchmark.measureStringParsing         thrpt   12  11.709 ± 0.225  ops/us

main:
AccessExpressionBenchmark.measureBytesParsing          thrpt   12  12.864 ± 0.278  ops/us
AccessExpressionBenchmark.measureEvaluation            thrpt   12  16.849 ± 0.312  ops/us
AccessExpressionBenchmark.measureEvaluationAndParsing  thrpt   12   8.480 ± 0.094  ops/us
AccessExpressionBenchmark.measureStringParsing         thrpt   12  11.482 ± 0.033  ops/us


test-perf-fixes:
AccessExpressionBenchmark.measureBytesParsing          thrpt   12  12.555 ± 0.196  ops/us
AccessExpressionBenchmark.measureEvaluation            thrpt   12  16.651 ± 0.730  ops/us
AccessExpressionBenchmark.measureEvaluationAndParsing  thrpt   12   8.432 ± 0.094  ops/us
AccessExpressionBenchmark.measureStringParsing         thrpt   12  11.601 ± 0.209  ops/us
```