### PR TITLE
replaces stream with loop to increase performance

### DIFF
--- a/src/main/java/org/apache/accumulo/access/AccessEvaluatorImpl.java
+++ b/src/main/java/org/apache/accumulo/access/AccessEvaluatorImpl.java
@@ -148,7 +148,12 @@ class AccessEvaluatorImpl implements AccessEvaluator {
       throws IllegalAccessExpressionException {
     // The AccessEvaluator computes a trie from the given Authorizations, that AccessExpressions can
     // be evaluated against.
-    return authorizedPredicates.stream().allMatch(accessExpression.aeNode::canAccess);
+    for(var auths : authorizedPredicates) {
+      if(!accessExpression.aeNode.canAccess(auths)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private static class BuilderImpl implements AuthorizationsBuilder, EvaluatorBuilder {

--- a/src/main/java/org/apache/accumulo/access/AccessEvaluatorImpl.java
+++ b/src/main/java/org/apache/accumulo/access/AccessEvaluatorImpl.java
@@ -148,8 +148,8 @@ class AccessEvaluatorImpl implements AccessEvaluator {
       throws IllegalAccessExpressionException {
     // The AccessEvaluator computes a trie from the given Authorizations, that AccessExpressions can
     // be evaluated against.
-    for(var auths : authorizedPredicates) {
-      if(!accessExpression.aeNode.canAccess(auths)) {
+    for (var auths : authorizedPredicates) {
+      if (!accessExpression.aeNode.canAccess(auths)) {
         return false;
       }
     }


### PR DESCRIPTION
This commit removes a stream used during expression evaluation. Removing it made a noticable performance difference. Seeing the following numbers in the performance test related to evaluation with this change.

```
Benchmark                                               Mode  Cnt   Score   Error   Units
AccessExpressionBenchmark.measureEvaluation            thrpt   12  20.230 ± 0.331  ops/us
AccessExpressionBenchmark.measureEvaluationAndParsing  thrpt   12   8.415 ± 0.206  ops/us
```

Running the same test without these changes seeing the following.

```
Benchmark                                               Mode  Cnt   Score   Error   Units
AccessExpressionBenchmark.measureEvaluation            thrpt   12  14.664 ± 0.937  ops/us
AccessExpressionBenchmark.measureEvaluationAndParsing  thrpt   12   6.988 ± 0.352  ops/us
```