### PR TITLE
Adds check for classes in public API

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -57,6 +57,8 @@ jobs:
       run: src/build/ci/find-unapproved-chars.sh
     - name: Check for unapproved JUnit API usage
       run: src/build/ci/find-unapproved-junit.sh
+    - name: Check for unapproved public classes
+      run: src/build/ci/find-unapproved-public.sh
     - name: Build with Maven (Fast Build)
       timeout-minutes: 20
       run: mvn -B -V -e -ntp "-Dstyle.color=always" clean package dependency:resolve -DskipTests -DskipFormat -DverifyFormat

--- a/src/build/ci/find-unapproved-public.sh
+++ b/src/build/ci/find-unapproved-public.sh
@@ -1,0 +1,30 @@
+#! /usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+count=$(grep -E "public.*(class|interface|enum|record)" src/main/java/org/apache/accumulo/access/*.java |
+  grep -v AccessEvaluator |
+  grep -v AccessExpression |
+  grep -v Authorizations |
+  grep -c -v IllegalAccessExpressionException)
+
+if [[ 0 -ne $count ]]; then
+  echo "$count unapproved public classes found"
+  exit 1
+fi

--- a/src/main/java/org/apache/accumulo/access/ByteUtils.java
+++ b/src/main/java/org/apache/accumulo/access/ByteUtils.java
@@ -22,37 +22,37 @@ package org.apache.accumulo.access;
  * This class exists to avoid repeat conversions from byte to char as well as to provide helper
  * methods for comparing them.
  */
-public final class ByteUtils {
-  public static final byte QUOTE = (byte) '"';
-  public static final byte BACKSLASH = (byte) '\\';
-  public static final byte AND_OPERATOR = (byte) '&';
-  public static final byte OR_OPERATOR = (byte) '|';
+final class ByteUtils {
+  static final byte QUOTE = (byte) '"';
+  static final byte BACKSLASH = (byte) '\\';
+  static final byte AND_OPERATOR = (byte) '&';
+  static final byte OR_OPERATOR = (byte) '|';
 
   private ByteUtils() {
     // private constructor to prevent instantiation
   }
 
-  public static boolean isQuoteSymbol(byte b) {
+  static boolean isQuoteSymbol(byte b) {
     return b == QUOTE;
   }
 
-  public static boolean isBackslashSymbol(byte b) {
+  static boolean isBackslashSymbol(byte b) {
     return b == BACKSLASH;
   }
 
-  public static boolean isQuoteOrSlash(byte b) {
+  static boolean isQuoteOrSlash(byte b) {
     return isQuoteSymbol(b) || isBackslashSymbol(b);
   }
 
-  public static boolean isAndOperator(byte b) {
+  static boolean isAndOperator(byte b) {
     return b == AND_OPERATOR;
   }
 
-  public static boolean isOrOperator(byte b) {
+  static boolean isOrOperator(byte b) {
     return b == OR_OPERATOR;
   }
 
-  public static boolean isAndOrOperator(byte b) {
+  static boolean isAndOrOperator(byte b) {
     return isAndOperator(b) || isOrOperator(b);
   }
 }


### PR DESCRIPTION
Adds a script to check which top level classes are in the public API. This is not something apilyzer can do, it can only check that the top level classes do not use non-public API types.  So this script along with aplyizer should avoid unintended types from leaking into the public API.