### PR TITLE
Bumped SpotBugs and ErrorProne plugins, marked classes final

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -71,7 +71,7 @@ jobs:
       matrix:
         profile:
           - {name: 'unit-tests',    distribution: adopt,  javaver: 17, args: 'verify -PskipQA'}
-          - {name: 'qa-checks',     distribution: adopt,  javaver: 17, args: 'verify javadoc:jar -Psec-bugs,errorprone'}
+          - {name: 'qa-checks',     distribution: adopt,  javaver: 17, args: 'verify javadoc:jar -Perrorprone'}
           - {name: 'jdk21',         distribution: oracle, javaver: 21, args: 'verify'}
       fail-fast: false
     runs-on: ubuntu-latest

--- a/pom.xml
+++ b/pom.xml
@@ -91,14 +91,14 @@
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <minimalJavaBuildVersion>17</minimalJavaBuildVersion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.errorprone>2.20.0</version.errorprone>
+    <version.errorprone>2.24.1</version.errorprone>
     <version.jmh>1.36</version.jmh>
   </properties>
   <dependencies>
     <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
-      <version>4.7.3</version>
+      <version>4.8.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -250,7 +250,7 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.7.3.6</version>
+        <version>4.8.3.0</version>
         <configuration>
           <excludeFilterFile>src/build/ci/spotbugs-exclude.xml</excludeFilterFile>
           <xmlOutput>true</xmlOutput>
@@ -260,6 +260,11 @@
           <maxRank>20</maxRank>
           <jvmArgs>-Dcom.overstock.findbugs.ignore=com.google.common.util.concurrent.RateLimiter,com.google.common.hash.Hasher,com.google.common.hash.HashCode,com.google.common.hash.HashFunction,com.google.common.hash.Hashing,com.google.common.cache.Cache,com.google.common.io.CountingOutputStream,com.google.common.io.ByteStreams,com.google.common.cache.LoadingCache,com.google.common.base.Stopwatch,com.google.common.cache.RemovalNotification,com.google.common.util.concurrent.Uninterruptibles,com.google.common.reflect.ClassPath,com.google.common.reflect.ClassPath$ClassInfo,com.google.common.base.Throwables,com.google.common.collect.Iterators</jvmArgs>
           <plugins combine.children="append">
+            <plugin>
+              <groupId>com.h3xstream.findsecbugs</groupId>
+              <artifactId>findsecbugs-plugin</artifactId>
+              <version>1.12.0</version>
+            </plugin>
             <plugin>
               <groupId>com.overstock.findbugs</groupId>
               <artifactId>library-detectors</artifactId>
@@ -635,27 +640,6 @@
                 </goals>
               </execution>
             </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>sec-bugs</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs-maven-plugin</artifactId>
-            <version>4.7.3.6</version>
-            <configuration>
-              <plugins>
-                <plugin>
-                  <groupId>com.h3xstream.findsecbugs</groupId>
-                  <artifactId>findsecbugs-plugin</artifactId>
-                  <version>1.12.0</version>
-                </plugin>
-              </plugins>
-            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/src/main/java/org/apache/accumulo/access/AccessEvaluatorImpl.java
+++ b/src/main/java/org/apache/accumulo/access/AccessEvaluatorImpl.java
@@ -33,7 +33,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 //this class is intentionally package private and should never be made public
-class AccessEvaluatorImpl implements AccessEvaluator {
+final class AccessEvaluatorImpl implements AccessEvaluator {
   private final Collection<Predicate<BytesWrapper>> authorizedPredicates;
 
   private static final byte[] EMPTY = new byte[0];

--- a/src/main/java/org/apache/accumulo/access/AccessExpressionImpl.java
+++ b/src/main/java/org/apache/accumulo/access/AccessExpressionImpl.java
@@ -23,7 +23,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.util.HashSet;
 import java.util.function.Predicate;
 
-class AccessExpressionImpl implements AccessExpression {
+final class AccessExpressionImpl implements AccessExpression {
 
   public static final AccessExpression EMPTY = new AccessExpressionImpl("", false);
 
@@ -140,4 +140,5 @@ class AccessExpressionImpl implements AccessExpression {
     Tokenizer tokenizer = new Tokenizer(expression);
     return Normalizer.normalize(tokenizer);
   }
+
 }

--- a/src/main/java/org/apache/accumulo/access/Authorizations.java
+++ b/src/main/java/org/apache/accumulo/access/Authorizations.java
@@ -28,7 +28,7 @@ import java.util.Set;
  *
  * @since 1.0.0
  */
-public class Authorizations {
+public final class Authorizations {
   private final Set<String> authorizations;
 
   private Authorizations(Set<String> authorizations) {

--- a/src/main/java/org/apache/accumulo/access/BytesWrapper.java
+++ b/src/main/java/org/apache/accumulo/access/BytesWrapper.java
@@ -22,7 +22,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.util.Arrays;
 
-class BytesWrapper implements Comparable<BytesWrapper> {
+final class BytesWrapper implements Comparable<BytesWrapper> {
 
   protected byte[] data;
   protected int offset;


### PR DESCRIPTION
Bumping SpotBugs flagged a couple of classes with CT_CONSTRUCTOR_THROW. Decided to mark all classes final, it's one of the remedies listed at https://spotbugs.readthedocs.io/en/stable/bugDescriptions.html#ct-be- wary-of-letting-constructors-throw-exceptions-ct-constructor-throw.

I also removed the sec-bugs profile and moved that plugin into the normal spotbugs run.