### PR TITLE
moves thread local access outside of loop

### DIFF
--- a/src/main/java/org/apache/accumulo/access/AccessEvaluatorImpl.java
+++ b/src/main/java/org/apache/accumulo/access/AccessEvaluatorImpl.java
@@ -196,9 +196,9 @@ final class AccessEvaluatorImpl implements AccessEvaluator {
 
   boolean evaluate(byte[] accessExpression) throws IllegalAccessExpressionException {
     var bytesWrapper = lookupWrappers.get();
+    var tokenizer = tokenizers.get();
 
     for (var auths : authorizedPredicates) {
-      var tokenizer = tokenizers.get();
       tokenizer.reset(accessExpression);
       Predicate<Tokenizer.AuthorizationToken> atp = authToken -> {
         bytesWrapper.set(authToken.data, authToken.start, authToken.len);


### PR DESCRIPTION
A thread local was being accessed multiple times in a loop.  The result should be the same each time, so the access was moved out of the loop to avoid any cost related to accessing a thread local.