### PR TITLE
Fixes issue #66: adds a restriction info object that the UI can pull if it is present

### DIFF
--- a/src/main/java/org/apache/accumulo/access/Authorizations.java
+++ b/src/main/java/org/apache/accumulo/access/Authorizations.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.access;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
 
@@ -64,7 +65,8 @@ public final class Authorizations {
   }
 
   public static Authorizations of(String... authorizations) {
-    return new Authorizations(Set.of(authorizations));
+    // Use Set.copyOf to remove duplicates if they exist
+    return new Authorizations(Set.copyOf(Arrays.asList(authorizations)));
   }
 
   public static Authorizations of(Collection<String> authorizations) {

--- a/src/test/java/org/apache/accumulo/access/AuthorizationTest.java
+++ b/src/test/java/org/apache/accumulo/access/AuthorizationTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.access;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+public class AuthorizationTest {
+
+  @Test
+  public void testDuplicateExpressions() {
+    // Test that we can de-duplicate a list of String expressions
+    Set<String> expected = Set.of("A&B", "A&C");
+    var authorization = Authorizations.of("A&B", "A&C", "A&B", "A&B", "A&C");
+    assertEquals(expected, authorization.asSet());
+  }
+}


### PR DESCRIPTION
I didn't add additional null checks, which could be added as tests into AuthorizationsTests.

It felt less clean to ingest the singular test into AccessExpressionTest or AccessEvaluatorTest, but happy to get feedback. I'm new to this particular project so this is kind of a feeler. 