### PR TITLE
Modified Authorizations.of to handle duplicate input elements

### DIFF
--- a/src/it/antlr4-example/src/test/java/org/apache/accumulo/access/grammar/antlr/AccessExpressionAntlrBenchmark.java
+++ b/src/it/antlr4-example/src/test/java/org/apache/accumulo/access/grammar/antlr/AccessExpressionAntlrBenchmark.java
@@ -25,6 +25,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -86,7 +87,7 @@ public class AccessExpressionAntlrBenchmark {
         et.expressions = new ArrayList<>();
 
         et.evaluator = new AccessExpressionAntlrEvaluator(
-            Stream.of(testDataSet.auths).map(a -> Authorizations.of(false, a)).collect(Collectors.toList()));
+            Stream.of(testDataSet.auths).map(a -> Authorizations.of(Set.of(a))).collect(Collectors.toList()));
 
         for (var tests : testDataSet.tests) {
           if (tests.expectedResult != TestDataLoader.ExpectedResult.ERROR) {

--- a/src/it/antlr4-example/src/test/java/org/apache/accumulo/access/grammar/antlr/AccessExpressionAntlrBenchmark.java
+++ b/src/it/antlr4-example/src/test/java/org/apache/accumulo/access/grammar/antlr/AccessExpressionAntlrBenchmark.java
@@ -86,7 +86,7 @@ public class AccessExpressionAntlrBenchmark {
         et.expressions = new ArrayList<>();
 
         et.evaluator = new AccessExpressionAntlrEvaluator(
-            Stream.of(testDataSet.auths).map(Authorizations::of).collect(Collectors.toList()));
+            Stream.of(testDataSet.auths).map(a -> Authorizations.of(false, a)).collect(Collectors.toList()));
 
         for (var tests : testDataSet.tests) {
           if (tests.expectedResult != TestDataLoader.ExpectedResult.ERROR) {

--- a/src/it/antlr4-example/src/test/java/org/apache/accumulo/access/grammar/antlr/Antlr4Tests.java
+++ b/src/it/antlr4-example/src/test/java/org/apache/accumulo/access/grammar/antlr/Antlr4Tests.java
@@ -120,7 +120,7 @@ public class Antlr4Tests {
   @Test
   public void testSimpleEvaluation() throws Exception {
     String accessExpression = "(one&two)|(foo&bar)";
-    Authorizations auths = Authorizations.of("four", "three", "one", "two");
+    Authorizations auths = Authorizations.of(false, "four", "three", "one", "two");
     AccessExpressionAntlrEvaluator eval = new AccessExpressionAntlrEvaluator(List.of(auths));
     assertTrue(eval.canAccess(accessExpression));
   }
@@ -128,7 +128,7 @@ public class Antlr4Tests {
   @Test
   public void testSimpleEvaluationFailure() throws Exception {
     String accessExpression = "(A&B&C)";
-    Authorizations auths = Authorizations.of("A", "C");
+    Authorizations auths = Authorizations.of(false, "A", "C");
     AccessExpressionAntlrEvaluator eval = new AccessExpressionAntlrEvaluator(List.of(auths));
     assertFalse(eval.canAccess(accessExpression));
   }
@@ -141,7 +141,7 @@ public class Antlr4Tests {
     for (TestDataSet testSet : testData) {
 
       List<Authorizations> authSets =
-          Stream.of(testSet.auths).map(Authorizations::of).collect(Collectors.toList());
+          Stream.of(testSet.auths).map(a -> Authorizations.of(false, a)).collect(Collectors.toList());
       AccessEvaluator evaluator = AccessEvaluator.of(authSets);
       AccessExpressionAntlrEvaluator antlr = new AccessExpressionAntlrEvaluator(authSets);
 

--- a/src/it/antlr4-example/src/test/java/org/apache/accumulo/access/grammar/antlr/Antlr4Tests.java
+++ b/src/it/antlr4-example/src/test/java/org/apache/accumulo/access/grammar/antlr/Antlr4Tests.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -120,7 +121,7 @@ public class Antlr4Tests {
   @Test
   public void testSimpleEvaluation() throws Exception {
     String accessExpression = "(one&two)|(foo&bar)";
-    Authorizations auths = Authorizations.of(false, "four", "three", "one", "two");
+    Authorizations auths = Authorizations.of(Set.of("four", "three", "one", "two"));
     AccessExpressionAntlrEvaluator eval = new AccessExpressionAntlrEvaluator(List.of(auths));
     assertTrue(eval.canAccess(accessExpression));
   }
@@ -128,7 +129,7 @@ public class Antlr4Tests {
   @Test
   public void testSimpleEvaluationFailure() throws Exception {
     String accessExpression = "(A&B&C)";
-    Authorizations auths = Authorizations.of(false, "A", "C");
+    Authorizations auths = Authorizations.of(Set.of("A", "C"));
     AccessExpressionAntlrEvaluator eval = new AccessExpressionAntlrEvaluator(List.of(auths));
     assertFalse(eval.canAccess(accessExpression));
   }
@@ -141,7 +142,7 @@ public class Antlr4Tests {
     for (TestDataSet testSet : testData) {
 
       List<Authorizations> authSets =
-          Stream.of(testSet.auths).map(a -> Authorizations.of(false, a)).collect(Collectors.toList());
+          Stream.of(testSet.auths).map(a -> Authorizations.of(Set.of(a))).collect(Collectors.toList());
       AccessEvaluator evaluator = AccessEvaluator.of(authSets);
       AccessExpressionAntlrEvaluator antlr = new AccessExpressionAntlrEvaluator(authSets);
 

--- a/src/main/java/org/apache/accumulo/access/AccessEvaluator.java
+++ b/src/main/java/org/apache/accumulo/access/AccessEvaluator.java
@@ -153,13 +153,6 @@ public interface AccessEvaluator {
   }
 
   /**
-   * Allows specifying a single set of authorizations.
-   */
-  static AccessEvaluator of(String... authorizations) {
-    return new AccessEvaluatorImpl(AccessEvaluatorImpl.convert(authorizations));
-  }
-
-  /**
    * An interface that is used to check if an authorization seen in an access expression is
    * authorized.
    *

--- a/src/main/java/org/apache/accumulo/access/AccessEvaluatorImpl.java
+++ b/src/main/java/org/apache/accumulo/access/AccessEvaluatorImpl.java
@@ -56,14 +56,6 @@ final class AccessEvaluatorImpl implements AccessEvaluator {
     return authorizationLists;
   }
 
-  static Collection<List<byte[]>> convert(String... authorizations) {
-    final List<byte[]> authList = new ArrayList<>(authorizations.length);
-    for (final String auth : authorizations) {
-      authList.add(auth.getBytes(UTF_8));
-    }
-    return Collections.singletonList(authList);
-  }
-
   static Collection<List<byte[]>> convert(Authorizations authorizations) {
     final Set<String> authSet = authorizations.asSet();
     final List<byte[]> authList = new ArrayList<>(authSet.size());

--- a/src/main/java/org/apache/accumulo/access/AccessExpressionImpl.java
+++ b/src/main/java/org/apache/accumulo/access/AccessExpressionImpl.java
@@ -75,7 +75,7 @@ final class AccessExpressionImpl implements AccessExpression {
 
   @Override
   public Authorizations getAuthorizations() {
-    return AccessExpressionImpl.getAuthorizations(expression);
+    return getAuthorizations(expression);
   }
 
   static Authorizations getAuthorizations(byte[] expression) {
@@ -86,7 +86,7 @@ final class AccessExpressionImpl implements AccessExpression {
       return true;
     };
     ParserEvaluator.parseAccessExpression(tokenizer, atp, atp);
-    return Authorizations.of(false, auths);
+    return Authorizations.of(auths);
   }
 
   static Authorizations getAuthorizations(String expression) {

--- a/src/main/java/org/apache/accumulo/access/AccessExpressionImpl.java
+++ b/src/main/java/org/apache/accumulo/access/AccessExpressionImpl.java
@@ -86,7 +86,7 @@ final class AccessExpressionImpl implements AccessExpression {
       return true;
     };
     ParserEvaluator.parseAccessExpression(tokenizer, atp, atp);
-    return Authorizations.of(auths);
+    return Authorizations.of(false, auths);
   }
 
   static Authorizations getAuthorizations(String expression) {

--- a/src/main/java/org/apache/accumulo/access/Authorizations.java
+++ b/src/main/java/org/apache/accumulo/access/Authorizations.java
@@ -18,6 +18,7 @@
  */
 package org.apache.accumulo.access;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
 
@@ -39,6 +40,11 @@ public final class Authorizations {
     this.authorizations = Set.copyOf(authorizations);
   }
 
+  /**
+   * Returns the set of authorization strings in this Authorization object
+   *
+   * @return set of authorization strings
+   */
   public Set<String> asSet() {
     return authorizations;
   }
@@ -63,12 +69,37 @@ public final class Authorizations {
     return authorizations.toString();
   }
 
-  public static Authorizations of(String... authorizations) {
-    return new Authorizations(Set.of(authorizations));
+  /**
+   * Creates an Authorizations object from the list of input authorization strings. Duplicate values
+   * are removed from the input list
+   *
+   * @param failOnDuplicates throw an exception if there are duplicates in the input
+   * @param authorizations list of authorization strings
+   * @return Authorizations object
+   * @throws IllegalArgumentException if failOnDuplicates is true and duplicates in the input
+   */
+  public static Authorizations of(boolean failOnDuplicates, String... authorizations) {
+    return failOnDuplicates ? new Authorizations(Set.of(authorizations))
+        : of(false, Arrays.asList(authorizations));
   }
 
-  public static Authorizations of(Collection<String> authorizations) {
-    return new Authorizations(Set.copyOf(authorizations));
+  /**
+   * Creates an Authorizations object from the collection of input authorization strings. Duplicate
+   * values are removed from the input list
+   *
+   * @param failOnDuplicates throw an exception if there are duplicates in the input
+   * @param authorizations list of authorization strings
+   * @return Authorizations object
+   * @throws IllegalArgumentException if failOnDuplicates is true and duplicates in the input
+   */
+  public static Authorizations of(boolean failOnDuplicates, Collection<String> authorizations) {
+    Set<String> auths = Set.copyOf(authorizations);
+    if (failOnDuplicates) {
+      if (authorizations.size() != auths.size()) {
+        throw new IllegalArgumentException("duplicate element found in input");
+      }
+    }
+    return new Authorizations(auths);
   }
 
 }

--- a/src/main/java/org/apache/accumulo/access/Authorizations.java
+++ b/src/main/java/org/apache/accumulo/access/Authorizations.java
@@ -18,8 +18,6 @@
  */
 package org.apache.accumulo.access;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Set;
 
 /**
@@ -34,6 +32,7 @@ import java.util.Set;
  * @since 1.0.0
  */
 public final class Authorizations {
+
   private final Set<String> authorizations;
 
   private Authorizations(Set<String> authorizations) {
@@ -70,36 +69,13 @@ public final class Authorizations {
   }
 
   /**
-   * Creates an Authorizations object from the list of input authorization strings. Duplicate values
-   * are removed from the input list
+   * Creates an Authorizations object from the set of input authorization strings.
    *
-   * @param failOnDuplicates throw an exception if there are duplicates in the input
    * @param authorizations list of authorization strings
    * @return Authorizations object
-   * @throws IllegalArgumentException if failOnDuplicates is true and duplicates in the input
    */
-  public static Authorizations of(boolean failOnDuplicates, String... authorizations) {
-    return failOnDuplicates ? new Authorizations(Set.of(authorizations))
-        : of(false, Arrays.asList(authorizations));
-  }
-
-  /**
-   * Creates an Authorizations object from the collection of input authorization strings. Duplicate
-   * values are removed from the input list
-   *
-   * @param failOnDuplicates throw an exception if there are duplicates in the input
-   * @param authorizations list of authorization strings
-   * @return Authorizations object
-   * @throws IllegalArgumentException if failOnDuplicates is true and duplicates in the input
-   */
-  public static Authorizations of(boolean failOnDuplicates, Collection<String> authorizations) {
-    Set<String> auths = Set.copyOf(authorizations);
-    if (failOnDuplicates) {
-      if (authorizations.size() != auths.size()) {
-        throw new IllegalArgumentException("duplicate element found in input");
-      }
-    }
-    return new Authorizations(auths);
+  public static Authorizations of(Set<String> authorizations) {
+    return new Authorizations(authorizations);
   }
 
 }

--- a/src/main/java/org/apache/accumulo/access/Authorizations.java
+++ b/src/main/java/org/apache/accumulo/access/Authorizations.java
@@ -71,7 +71,7 @@ public final class Authorizations {
   /**
    * Creates an Authorizations object from the set of input authorization strings.
    *
-   * @param authorizations list of authorization strings
+   * @param authorizations set of authorization strings
    * @return Authorizations object
    */
   public static Authorizations of(Set<String> authorizations) {

--- a/src/main/java/org/apache/accumulo/access/Authorizations.java
+++ b/src/main/java/org/apache/accumulo/access/Authorizations.java
@@ -42,7 +42,7 @@ public final class Authorizations {
   /**
    * Returns the set of authorization strings in this Authorization object
    *
-   * @return set of authorization strings
+   * @return immutable set of authorization strings
    */
   public Set<String> asSet() {
     return authorizations;

--- a/src/test/java/example/AccessExample.java
+++ b/src/test/java/example/AccessExample.java
@@ -22,9 +22,11 @@ package example;
 import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 import org.apache.accumulo.access.AccessEvaluator;
+import org.apache.accumulo.access.Authorizations;
 
 public class AccessExample {
 
@@ -56,7 +58,7 @@ public class AccessExample {
         Arrays.toString(authorizations));
 
     // Create an access evaluator using the provided authorizations
-    AccessEvaluator evaluator = AccessEvaluator.of(authorizations);
+    AccessEvaluator evaluator = AccessEvaluator.of(Authorizations.of(Set.of(authorizations)));
 
     // Print each record whose access expression permits viewing using the provided authorizations
     getData().forEach((record, accessExpression) -> {

--- a/src/test/java/org/apache/accumulo/access/AccessEvaluatorTest.java
+++ b/src/test/java/org/apache/accumulo/access/AccessEvaluatorTest.java
@@ -91,8 +91,8 @@ public class AccessEvaluatorTest {
         evaluator = AccessEvaluator.of(auths::contains);
         runTestCases(testSet, evaluator);
       } else {
-        var authSets =
-            Stream.of(testSet.auths).map(Authorizations::of).collect(Collectors.toList());
+        var authSets = Stream.of(testSet.auths).map(a -> Authorizations.of(false, a))
+            .collect(Collectors.toList());
         evaluator = AccessEvaluator.of(authSets);
         runTestCases(testSet, evaluator);
       }
@@ -187,7 +187,8 @@ public class AccessEvaluatorTest {
     assertThrows(IllegalArgumentException.class, () -> AccessEvaluator.of(""));
     assertThrows(IllegalArgumentException.class, () -> AccessEvaluator.of("", "A"));
     assertThrows(IllegalArgumentException.class, () -> AccessEvaluator.of("A", ""));
-    assertThrows(IllegalArgumentException.class, () -> AccessEvaluator.of(Authorizations.of("")));
+    assertThrows(IllegalArgumentException.class,
+        () -> AccessEvaluator.of(Authorizations.of(false, "")));
   }
 
   @Test

--- a/src/test/java/org/apache/accumulo/access/AccessEvaluatorTest.java
+++ b/src/test/java/org/apache/accumulo/access/AccessEvaluatorTest.java
@@ -84,14 +84,14 @@ public class AccessEvaluatorTest {
       AccessEvaluator evaluator;
       assertTrue(testSet.auths.length >= 1);
       if (testSet.auths.length == 1) {
-        evaluator = AccessEvaluator.of(testSet.auths[0]);
+        evaluator = AccessEvaluator.of(Authorizations.of(Set.of(testSet.auths[0])));
         runTestCases(testSet, evaluator);
 
         Set<String> auths = Stream.of(testSet.auths[0]).collect(Collectors.toSet());
         evaluator = AccessEvaluator.of(auths::contains);
         runTestCases(testSet, evaluator);
       } else {
-        var authSets = Stream.of(testSet.auths).map(a -> Authorizations.of(false, a))
+        var authSets = Stream.of(testSet.auths).map(a -> Authorizations.of(Set.of(a)))
             .collect(Collectors.toList());
         evaluator = AccessEvaluator.of(authSets);
         runTestCases(testSet, evaluator);
@@ -184,11 +184,14 @@ public class AccessEvaluatorTest {
 
   @Test
   public void testEmptyAuthorizations() {
-    assertThrows(IllegalArgumentException.class, () -> AccessEvaluator.of(""));
-    assertThrows(IllegalArgumentException.class, () -> AccessEvaluator.of("", "A"));
-    assertThrows(IllegalArgumentException.class, () -> AccessEvaluator.of("A", ""));
     assertThrows(IllegalArgumentException.class,
-        () -> AccessEvaluator.of(Authorizations.of(false, "")));
+        () -> AccessEvaluator.of(Authorizations.of(Set.of(""))));
+    assertThrows(IllegalArgumentException.class,
+        () -> AccessEvaluator.of(Authorizations.of(Set.of("", "A"))));
+    assertThrows(IllegalArgumentException.class,
+        () -> AccessEvaluator.of(Authorizations.of(Set.of("A", ""))));
+    assertThrows(IllegalArgumentException.class,
+        () -> AccessEvaluator.of(Authorizations.of(Set.of(""))));
   }
 
   @Test

--- a/src/test/java/org/apache/accumulo/access/AccessExpressionBenchmark.java
+++ b/src/test/java/org/apache/accumulo/access/AccessExpressionBenchmark.java
@@ -87,8 +87,8 @@ public class AccessExpressionBenchmark {
         if (testDataSet.auths.length == 1) {
           et.evaluator = AccessEvaluator.of(testDataSet.auths[0]);
         } else {
-          var authSets =
-              Stream.of(testDataSet.auths).map(Authorizations::of).collect(Collectors.toList());
+          var authSets = Stream.of(testDataSet.auths).map(a -> Authorizations.of(false, a))
+              .collect(Collectors.toList());
           et.evaluator = AccessEvaluator.of(authSets);
         }
 

--- a/src/test/java/org/apache/accumulo/access/AccessExpressionBenchmark.java
+++ b/src/test/java/org/apache/accumulo/access/AccessExpressionBenchmark.java
@@ -23,6 +23,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -85,9 +86,9 @@ public class AccessExpressionBenchmark {
         et.expressions = new ArrayList<>();
 
         if (testDataSet.auths.length == 1) {
-          et.evaluator = AccessEvaluator.of(testDataSet.auths[0]);
+          et.evaluator = AccessEvaluator.of(Authorizations.of(Set.of(testDataSet.auths[0])));
         } else {
-          var authSets = Stream.of(testDataSet.auths).map(a -> Authorizations.of(false, a))
+          var authSets = Stream.of(testDataSet.auths).map(a -> Authorizations.of(Set.of(a)))
               .collect(Collectors.toList());
           et.evaluator = AccessEvaluator.of(authSets);
         }

--- a/src/test/java/org/apache/accumulo/access/AuthorizationTest.java
+++ b/src/test/java/org/apache/accumulo/access/AuthorizationTest.java
@@ -19,10 +19,9 @@
 package org.apache.accumulo.access;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -30,36 +29,16 @@ public class AuthorizationTest {
 
   @Test
   public void testEquality() {
-    Authorizations auths1 = Authorizations.of(false, "A", "B", "C");
-    Authorizations auths2 = Authorizations.of(false, "A", "B", "C");
-
-    assertEquals(auths1, auths2);
-    assertEquals(auths1.hashCode(), auths2.hashCode());
-  }
-
-  @Test
-  public void testDuplicateElementsInArray() {
-    Authorizations auths1 = Authorizations.of(false, "A", "B", "C");
-    Authorizations auths2 = Authorizations.of(false, "A", "A", "B", "C");
+    Authorizations auths1 = Authorizations.of(Set.of("A", "B", "C"));
+    Authorizations auths2 = Authorizations.of(Set.of("A", "B", "C"));
 
     assertEquals(auths1, auths2);
     assertEquals(auths1.hashCode(), auths2.hashCode());
 
-    assertNotNull(Authorizations.of(true, "A", "B", "C"));
-    assertThrows(IllegalArgumentException.class, () -> Authorizations.of(true, "A", "A", "B", "C"));
-  }
+    Authorizations auths3 = Authorizations.of(Set.of("D", "E", "F"));
 
-  @Test
-  public void testDuplicateElementsInCollection() {
-    Authorizations auths1 = Authorizations.of(false, List.of("A", "B", "C"));
-    Authorizations auths2 = Authorizations.of(false, List.of("A", "A", "B", "C"));
-
-    assertEquals(auths1, auths2);
-    assertEquals(auths1.hashCode(), auths2.hashCode());
-
-    assertNotNull(Authorizations.of(true, List.of("A", "B", "C")));
-    assertThrows(IllegalArgumentException.class,
-        () -> Authorizations.of(true, List.of("A", "A", "B", "C")));
+    assertNotEquals(auths1, auths3);
+    assertNotEquals(auths1.hashCode(), auths3.hashCode());
 
   }
 

--- a/src/test/java/org/apache/accumulo/access/AuthorizationTest.java
+++ b/src/test/java/org/apache/accumulo/access/AuthorizationTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.access;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+public class AuthorizationTest {
+
+  @Test
+  public void testEquality() {
+    Authorizations auths1 = Authorizations.of(false, "A", "B", "C");
+    Authorizations auths2 = Authorizations.of(false, "A", "B", "C");
+
+    assertEquals(auths1, auths2);
+    assertEquals(auths1.hashCode(), auths2.hashCode());
+  }
+
+  @Test
+  public void testDuplicateElementsInArray() {
+    Authorizations auths1 = Authorizations.of(false, "A", "B", "C");
+    Authorizations auths2 = Authorizations.of(false, "A", "A", "B", "C");
+
+    assertEquals(auths1, auths2);
+    assertEquals(auths1.hashCode(), auths2.hashCode());
+
+    assertNotNull(Authorizations.of(true, "A", "B", "C"));
+    assertThrows(IllegalArgumentException.class, () -> Authorizations.of(true, "A", "A", "B", "C"));
+  }
+
+  @Test
+  public void testDuplicateElementsInCollection() {
+    Authorizations auths1 = Authorizations.of(false, List.of("A", "B", "C"));
+    Authorizations auths2 = Authorizations.of(false, List.of("A", "A", "B", "C"));
+
+    assertEquals(auths1, auths2);
+    assertEquals(auths1.hashCode(), auths2.hashCode());
+
+    assertNotNull(Authorizations.of(true, List.of("A", "B", "C")));
+    assertThrows(IllegalArgumentException.class,
+        () -> Authorizations.of(true, List.of("A", "A", "B", "C")));
+
+  }
+
+}


### PR DESCRIPTION
Authorizations.of will either throw an IllegalArgumentException or deduplicate the input parameters depending on the value of a new boolean parameter.

Closes #66