### PR TITLE
Put benchmark config inside its execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ For an ANTLRv4 example, see antlr-example integration test's
 This project includes a JMH Benchmark. To run it:
 
 ```
-mvn clean verify -Pbenchmark"
+mvn clean verify -Pbenchmark
 ```
+
 
 [1]: https://github.com/apache/accumulo/blob/rel/2.1.2/core/src/main/java/org/apache/accumulo/core/security/ColumnVisibility.java
 [2]: https://github.com/apache/accumulo/blob/rel/2.1.2/core/src/main/java/org/apache/accumulo/core/security/VisibilityEvaluator.java

--- a/pom.xml
+++ b/pom.xml
@@ -765,21 +765,21 @@
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
             <version>3.3.0</version>
-            <configuration>
-              <classpathScope>test</classpathScope>
-              <executable>java</executable>
-              <arguments>
-                <argument>-classpath</argument>
-                <classpath />
-                <argument>org.apache.accumulo.access.AccessExpressionBenchmark</argument>
-              </arguments>
-            </configuration>
             <executions>
               <execution>
                 <goals>
                   <goal>exec</goal>
                 </goals>
                 <phase>verify</phase>
+                <configuration>
+                  <classpathScope>test</classpathScope>
+                  <executable>java</executable>
+                  <arguments>
+                    <argument>-classpath</argument>
+                    <classpath />
+                    <argument>org.apache.accumulo.access.AccessExpressionBenchmark</argument>
+                  </arguments>
+                </configuration>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
* Configuration outside of the execution will apply to all executions of exec-maven-plugin when the profile is active, even executions that have nothing to do with the benchmark, so the benchmark-specific configuration should be contained inside the execution element
* Remove extra character from README