### PR TITLE
memoizes creating a parse tree

### DIFF
--- a/src/main/java/org/apache/accumulo/access/AccessExpression.java
+++ b/src/main/java/org/apache/accumulo/access/AccessExpression.java
@@ -107,6 +107,15 @@ public abstract class AccessExpression implements Serializable {
    */
   public abstract String getExpression();
 
+  /**
+   * Parses the access expression if it was never parsed before. If this access expression was
+   * created using {@link #parse(String)} or {@link #parse(byte[])} then it will have a parse from
+   * inception and this method will return itself. If the access expression was created using
+   * {@link #of(String)} or {@link #of(byte[])} then this method will create a parse tree the first
+   * time its called and remember it, returning the remembered parse tree on subsequent calls.
+   */
+  public abstract ParsedAccessExpression parse();
+
   @Override
   public boolean equals(Object o) {
     if (o instanceof AccessExpression) {
@@ -170,7 +179,9 @@ public abstract class AccessExpression implements Serializable {
   /**
    * Validates an access expression and returns an immutable object with a parse tree. Creating the
    * parse tree is expensive relative to calling {@link #of(String)} or {@link #validate(String)},
-   * so only use this method when the parse tree is needed.
+   * so only use this method when the parse tree is always needed. If the code may only use the
+   * parse tree sometimes, then it may be best to call {@link #of(String)} to create the access
+   * expression and then call {@link AccessExpression#parse()} when needed.
    *
    * @throws NullPointerException when the argument is null
    * @throws InvalidAccessExpressionException if the given expression is not valid

--- a/src/main/java/org/apache/accumulo/access/AccessExpressionImpl.java
+++ b/src/main/java/org/apache/accumulo/access/AccessExpressionImpl.java
@@ -27,6 +27,7 @@ final class AccessExpressionImpl extends AccessExpression {
   public static final AccessExpression EMPTY = new AccessExpressionImpl("");
 
   private final String expression;
+  private volatile ParsedAccessExpression parsed = null;
 
   AccessExpressionImpl(String expression) {
     validate(expression);
@@ -41,5 +42,17 @@ final class AccessExpressionImpl extends AccessExpression {
   @Override
   public String getExpression() {
     return expression;
+  }
+
+  @Override
+  public ParsedAccessExpression parse() {
+    if (parsed == null) {
+      synchronized (this) {
+        if (parsed == null) {
+          parsed = ParsedAccessExpressionImpl.parseExpression(expression.getBytes(UTF_8));
+        }
+      }
+    }
+    return parsed;
   }
 }

--- a/src/main/java/org/apache/accumulo/access/ParsedAccessExpressionImpl.java
+++ b/src/main/java/org/apache/accumulo/access/ParsedAccessExpressionImpl.java
@@ -94,6 +94,11 @@ final class ParsedAccessExpressionImpl extends ParsedAccessExpression {
   }
 
   @Override
+  public ParsedAccessExpression parse() {
+    return this;
+  }
+
+  @Override
   public ExpressionType getType() {
     return type;
   }


### PR DESCRIPTION
This change offers a new parse() method on AccessExpression that creates a parse tree if one does not exits.  This change allows decoupling how access expression are created (w/ or w/o an initial parse tree) from using parse trees.

For example code the like the following that wanted to use a parse tree to validate an access expression would have required the ParsedAccessExpression type to be passed to it.  Now it can accept an AccessExpression and call parse() which will do the most efficient thing depending on how the expression was created.

```java

void checkExpression(AccessExpression expression){
    var parsed = expression.parse();
    // use parse tree to validate expression
}

```