### PR TITLE
Changes exception prefix from Invalid to Illegal

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ section](#getting-started) for an example of how to use this java library.
 The following types constitute the public API of this library. All other types
 are package private and are not part of the public API.
 
-  * [InvalidAccessExpressionException](src/main/java/org/apache/accumulo/access/InvalidAccessExpressionException.java).
+  * [IllegalAccessExpressionException](src/main/java/org/apache/accumulo/access/IllegalAccessExpressionException.java).
   * [AccessEvaluator](src/main/java/org/apache/accumulo/access/AccessEvaluator.java).
   * [AccessExpression](src/main/java/org/apache/accumulo/access/AccessExpression.java).
   * [ParsedAccessExpression](src/main/java/org/apache/accumulo/access/ParsedAccessExpression.java).

--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,7 @@
             </goals>
             <configuration>
               <includes>
-                <include>org[.]apache[.]accumulo[.]access[.]InvalidAccessExpressionException</include>
+                <include>org[.]apache[.]accumulo[.]access[.]IllegalAccessExpressionException</include>
                 <include>org[.]apache[.]accumulo[.]access[.]AccessExpression</include>
                 <include>org[.]apache[.]accumulo[.]access[.]AccessEvaluator</include>
                 <include>org[.]apache[.]accumulo[.]access[.]Authorizations</include>

--- a/src/build/ci/find-unapproved-public.sh
+++ b/src/build/ci/find-unapproved-public.sh
@@ -24,7 +24,7 @@ count=$(grep -E "public.*(class|interface|enum|record)" src/main/java/org/apache
   grep -v " class ParsedAccessExpression " |
   grep -v " enum ExpressionType " |
   grep -v " class Authorizations " |
-  grep -c -v " class InvalidAccessExpressionException ")
+  grep -c -v " class IllegalAccessExpressionException ")
 
 if [[ 0 -ne $count ]]; then
   echo "$count unapproved public classes found"

--- a/src/it/antlr4-example/src/test/java/org/apache/accumulo/access/grammar/antlr/AccessExpressionAntlrEvaluator.java
+++ b/src/it/antlr4-example/src/test/java/org/apache/accumulo/access/grammar/antlr/AccessExpressionAntlrEvaluator.java
@@ -28,7 +28,7 @@ import org.antlr.v4.runtime.tree.TerminalNode;
 import org.apache.accumulo.access.AccessEvaluator;
 import org.apache.accumulo.access.AccessExpression;
 import org.apache.accumulo.access.Authorizations;
-import org.apache.accumulo.access.InvalidAccessExpressionException;
+import org.apache.accumulo.access.IllegalAccessExpressionException;
 import org.apache.accumulo.access.grammars.AccessExpressionParser.Access_expressionContext;
 import org.apache.accumulo.access.grammars.AccessExpressionParser.Access_tokenContext;
 import org.apache.accumulo.access.grammars.AccessExpressionParser.And_expressionContext;
@@ -70,7 +70,7 @@ public class AccessExpressionAntlrEvaluator implements AccessEvaluator {
     }
   }
 
-  public boolean canAccess(byte[] accessExpression) throws InvalidAccessExpressionException {
+  public boolean canAccess(byte[] accessExpression) throws IllegalAccessExpressionException {
     return canAccess(AccessExpression.of(accessExpression));
   }
 

--- a/src/it/antlr4-example/src/test/java/org/apache/accumulo/access/grammar/antlr/AccessExpressionAntlrParser.java
+++ b/src/it/antlr4-example/src/test/java/org/apache/accumulo/access/grammar/antlr/AccessExpressionAntlrParser.java
@@ -29,7 +29,7 @@ import org.antlr.v4.runtime.ConsoleErrorListener;
 import org.antlr.v4.runtime.LexerNoViableAltException;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
-import org.apache.accumulo.access.InvalidAccessExpressionException;
+import org.apache.accumulo.access.IllegalAccessExpressionException;
 import org.apache.accumulo.access.grammars.AccessExpressionLexer;
 import org.apache.accumulo.access.grammars.AccessExpressionParser;
 import org.apache.accumulo.access.grammars.AccessExpressionParser.Access_expressionContext;
@@ -84,12 +84,12 @@ public class AccessExpressionAntlrParser {
   }
 
   public static Access_expressionContext parseAccessExpression(byte[] accessExpression)
-      throws InvalidAccessExpressionException {
+      throws IllegalAccessExpressionException {
     return parseAccessExpression(new String(accessExpression, StandardCharsets.UTF_8));
   }
 
   public static Access_expressionContext parseAccessExpression(String accessExpression)
-      throws InvalidAccessExpressionException {
+      throws IllegalAccessExpressionException {
     CodePointCharStream input = CharStreams.fromString(accessExpression);
     AccessExpressionLexerWithErrors lexer = new AccessExpressionLexerWithErrors(input);
     AccessExpressionParser parser = new AccessExpressionParser(new CommonTokenStream(lexer));
@@ -103,11 +103,11 @@ public class AccessExpressionAntlrParser {
       errors = lexer.getErrorCount();
       errors += errorListener.getErrorCount();
       if (errors > 0 || parser.getNumberOfSyntaxErrors() > 0 || ctx.exception != null) {
-        throw new InvalidAccessExpressionException("Parse error", "", 0);
+        throw new IllegalAccessExpressionException("Parse error", "", 0);
       }
       return ctx;
     } catch (RuntimeException e1) {
-      throw new InvalidAccessExpressionException(e1.getMessage(), "", 0);
+      throw new IllegalAccessExpressionException(e1.getMessage(), "", 0);
     }
   }
 

--- a/src/it/antlr4-example/src/test/java/org/apache/accumulo/access/grammar/antlr/Antlr4Tests.java
+++ b/src/it/antlr4-example/src/test/java/org/apache/accumulo/access/grammar/antlr/Antlr4Tests.java
@@ -42,7 +42,7 @@ import org.antlr.v4.runtime.Recognizer;
 import org.apache.accumulo.access.AccessEvaluator;
 import org.apache.accumulo.access.AccessExpression;
 import org.apache.accumulo.access.Authorizations;
-import org.apache.accumulo.access.InvalidAccessExpressionException;
+import org.apache.accumulo.access.IllegalAccessExpressionException;
 import org.apache.accumulo.access.antlr.TestDataLoader;
 import org.apache.accumulo.access.antlr.TestDataLoader.ExpectedResult;
 import org.apache.accumulo.access.antlr.TestDataLoader.TestDataSet;
@@ -107,7 +107,7 @@ public class Antlr4Tests {
         ExpectedResult result = test.expectedResult;
         for (String cv : test.expressions) {
           if (result == ExpectedResult.ERROR) {
-            assertThrows(InvalidAccessExpressionException.class, () -> AccessExpression.of(cv));
+            assertThrows(IllegalAccessExpressionException.class, () -> AccessExpression.of(cv));
             assertThrows(AssertionError.class, () -> testParse(cv));
           } else {
             AccessExpression.of(cv);
@@ -184,23 +184,23 @@ public class Antlr4Tests {
 
               break;
             case ERROR:
-              assertThrows(InvalidAccessExpressionException.class,
+              assertThrows(IllegalAccessExpressionException.class,
                   () -> evaluator.canAccess(expression), expression);
-              assertThrows(InvalidAccessExpressionException.class,
+              assertThrows(IllegalAccessExpressionException.class,
                   () -> evaluator.canAccess(expression.getBytes(UTF_8)), expression);
-              assertThrows(InvalidAccessExpressionException.class,
+              assertThrows(IllegalAccessExpressionException.class,
                   () -> evaluator.canAccess(AccessExpression.of(expression)), expression);
-              assertThrows(InvalidAccessExpressionException.class,
+              assertThrows(IllegalAccessExpressionException.class,
                   () -> evaluator.canAccess(AccessExpression.of(expression.getBytes(UTF_8))),
                   expression);
 
-              assertThrows(InvalidAccessExpressionException.class,
+              assertThrows(IllegalAccessExpressionException.class,
                   () -> antlr.canAccess(expression), expression);
-              assertThrows(InvalidAccessExpressionException.class,
+              assertThrows(IllegalAccessExpressionException.class,
                   () -> antlr.canAccess(expression.getBytes(UTF_8)), expression);
-              assertThrows(InvalidAccessExpressionException.class,
+              assertThrows(IllegalAccessExpressionException.class,
                   () -> antlr.canAccess(AccessExpression.of(expression)), expression);
-              assertThrows(InvalidAccessExpressionException.class,
+              assertThrows(IllegalAccessExpressionException.class,
                   () -> antlr.canAccess(AccessExpression.of(expression.getBytes(UTF_8))),
                   expression);
               break;

--- a/src/main/java/org/apache/accumulo/access/AccessEvaluator.java
+++ b/src/main/java/org/apache/accumulo/access/AccessEvaluator.java
@@ -19,7 +19,6 @@
 package org.apache.accumulo.access;
 
 import java.util.Collection;
-import java.util.List;
 
 /**
  * This class is used to decide if an entity with a given set of authorizations can access
@@ -59,17 +58,17 @@ public interface AccessEvaluator {
    * @param accessExpression for this parameter a valid access expression is expected.
    * @return true if the expression is visible using the authorizations supplied at creation, false
    *         otherwise
-   * @throws InvalidAccessExpressionException when the expression is not valid
+   * @throws IllegalAccessExpressionException when the expression is not valid
    */
-  boolean canAccess(String accessExpression) throws InvalidAccessExpressionException;
+  boolean canAccess(String accessExpression) throws IllegalAccessExpressionException;
 
   /**
    * @param accessExpression for this parameter a valid access expression is expected.
    * @return true if the expression is visible using the authorizations supplied at creation, false
    *         otherwise
-   * @throws InvalidAccessExpressionException when the expression is not valid
+   * @throws IllegalAccessExpressionException when the expression is not valid
    */
-  boolean canAccess(byte[] accessExpression) throws InvalidAccessExpressionException;
+  boolean canAccess(byte[] accessExpression) throws IllegalAccessExpressionException;
 
   /**
    * @param accessExpression previously validated access expression

--- a/src/main/java/org/apache/accumulo/access/AccessEvaluatorImpl.java
+++ b/src/main/java/org/apache/accumulo/access/AccessEvaluatorImpl.java
@@ -137,16 +137,16 @@ final class AccessEvaluatorImpl implements AccessEvaluator {
   }
 
   @Override
-  public boolean canAccess(String expression) throws InvalidAccessExpressionException {
+  public boolean canAccess(String expression) throws IllegalAccessExpressionException {
     return evaluate(expression.getBytes(UTF_8));
   }
 
   @Override
-  public boolean canAccess(byte[] expression) throws InvalidAccessExpressionException {
+  public boolean canAccess(byte[] expression) throws IllegalAccessExpressionException {
     return evaluate(expression);
   }
 
-  boolean evaluate(byte[] accessExpression) throws InvalidAccessExpressionException {
+  boolean evaluate(byte[] accessExpression) throws IllegalAccessExpressionException {
     var bytesWrapper = ParserEvaluator.lookupWrappers.get();
     Predicate<Tokenizer.AuthorizationToken> atp = authToken -> {
       bytesWrapper.set(authToken.data, authToken.start, authToken.len);

--- a/src/main/java/org/apache/accumulo/access/AccessExpression.java
+++ b/src/main/java/org/apache/accumulo/access/AccessExpression.java
@@ -76,7 +76,7 @@ import java.util.function.Predicate;
  * }
  * </pre>
  *
- * The following code will throw an {@link InvalidAccessExpressionException} because the expression
+ * The following code will throw an {@link IllegalAccessExpressionException} because the expression
  * is not valid.
  *
  * <pre>
@@ -143,17 +143,17 @@ public abstract class AccessExpression implements Serializable {
    * {@link #validate(String)} and if that passes creates an immutable object that wraps the
    * expression.
    *
-   * @throws InvalidAccessExpressionException if the given expression is not valid
+   * @throws IllegalAccessExpressionException if the given expression is not valid
    * @throws NullPointerException when the argument is null
    */
-  public static AccessExpression of(String expression) throws InvalidAccessExpressionException {
+  public static AccessExpression of(String expression) throws IllegalAccessExpressionException {
     return new AccessExpressionImpl(expression);
   }
 
   /**
    * @see #of(String)
    */
-  public static AccessExpression of(byte[] expression) throws InvalidAccessExpressionException {
+  public static AccessExpression of(byte[] expression) throws IllegalAccessExpressionException {
     return new AccessExpressionImpl(expression);
   }
 
@@ -168,7 +168,7 @@ public abstract class AccessExpression implements Serializable {
    * @see #parse(String)
    */
   public static ParsedAccessExpression parse(byte[] expression)
-      throws InvalidAccessExpressionException {
+      throws IllegalAccessExpressionException {
     if (expression.length == 0) {
       return ParsedAccessExpressionImpl.EMPTY;
     }
@@ -184,10 +184,10 @@ public abstract class AccessExpression implements Serializable {
    * expression and then call {@link AccessExpression#parse()} when needed.
    *
    * @throws NullPointerException when the argument is null
-   * @throws InvalidAccessExpressionException if the given expression is not valid
+   * @throws IllegalAccessExpressionException if the given expression is not valid
    */
   public static ParsedAccessExpression parse(String expression)
-      throws InvalidAccessExpressionException {
+      throws IllegalAccessExpressionException {
     if (expression.isEmpty()) {
       return ParsedAccessExpressionImpl.EMPTY;
     }
@@ -201,10 +201,10 @@ public abstract class AccessExpression implements Serializable {
    * Quickly validates that an access expression is properly formed.
    *
    * @param expression a potential access expression that is expected to be encoded using UTF-8
-   * @throws InvalidAccessExpressionException if the given expression is not valid
+   * @throws IllegalAccessExpressionException if the given expression is not valid
    * @throws NullPointerException when the argument is null
    */
-  public static void validate(byte[] expression) throws InvalidAccessExpressionException {
+  public static void validate(byte[] expression) throws IllegalAccessExpressionException {
     if (expression.length > 0) {
       Predicate<Tokenizer.AuthorizationToken> atp = authToken -> true;
       ParserEvaluator.parseAccessExpression(expression, atp, atp);
@@ -214,7 +214,7 @@ public abstract class AccessExpression implements Serializable {
   /**
    * @see #validate(byte[])
    */
-  public static void validate(String expression) throws InvalidAccessExpressionException {
+  public static void validate(String expression) throws IllegalAccessExpressionException {
     if (!expression.isEmpty()) {
       validate(expression.getBytes(UTF_8));
     } // else empty expression is valid, avoid object allocation
@@ -233,11 +233,11 @@ public abstract class AccessExpression implements Serializable {
    * is already available, then it would likely be faster to use it rather than call this method.
    * </p>
    *
-   * @throws InvalidAccessExpressionException when the expression is not valid.
+   * @throws IllegalAccessExpressionException when the expression is not valid.
    * @throws NullPointerException when any argument is null
    */
   public static void findAuthorizations(String expression, Consumer<String> authorizationConsumer)
-      throws InvalidAccessExpressionException {
+      throws IllegalAccessExpressionException {
     findAuthorizations(expression.getBytes(UTF_8), authorizationConsumer);
   }
 
@@ -245,7 +245,7 @@ public abstract class AccessExpression implements Serializable {
    * @see #findAuthorizations(String, Consumer)
    */
   public static void findAuthorizations(byte[] expression, Consumer<String> authorizationConsumer)
-      throws InvalidAccessExpressionException {
+      throws IllegalAccessExpressionException {
     var bytesWrapper = ParserEvaluator.lookupWrappers.get();
     Predicate<Tokenizer.AuthorizationToken> atp = authToken -> {
       bytesWrapper.set(authToken.data, authToken.start, authToken.len);

--- a/src/main/java/org/apache/accumulo/access/IllegalAccessExpressionException.java
+++ b/src/main/java/org/apache/accumulo/access/IllegalAccessExpressionException.java
@@ -25,14 +25,13 @@ import java.util.regex.PatternSyntaxException;
  *
  * @since 1.0.0
  */
-// TODO rename to illegal...
-public final class InvalidAccessExpressionException extends IllegalArgumentException {
+public final class IllegalAccessExpressionException extends IllegalArgumentException {
 
   private static final long serialVersionUID = 1L;
 
   private final PatternSyntaxException delegate;
 
-  public InvalidAccessExpressionException(String desc, String badarg, int index) {
+  public IllegalAccessExpressionException(String desc, String badarg, int index) {
     super();
     delegate = new PatternSyntaxException(desc, badarg, index);
   }

--- a/src/main/java/org/apache/accumulo/access/MultiAccessEvaluatorImpl.java
+++ b/src/main/java/org/apache/accumulo/access/MultiAccessEvaluatorImpl.java
@@ -35,12 +35,12 @@ class MultiAccessEvaluatorImpl implements AccessEvaluator {
   }
 
   @Override
-  public boolean canAccess(String accessExpression) throws InvalidAccessExpressionException {
+  public boolean canAccess(String accessExpression) throws IllegalAccessExpressionException {
     return canAccess(accessExpression.getBytes(UTF_8));
   }
 
   @Override
-  public boolean canAccess(byte[] accessExpression) throws InvalidAccessExpressionException {
+  public boolean canAccess(byte[] accessExpression) throws IllegalAccessExpressionException {
     for (AccessEvaluatorImpl evaluator : evaluators) {
       if (!evaluator.canAccess(accessExpression)) {
         return false;

--- a/src/main/java/org/apache/accumulo/access/Tokenizer.java
+++ b/src/main/java/org/apache/accumulo/access/Tokenizer.java
@@ -95,7 +95,7 @@ final class Tokenizer {
   }
 
   public void error(String msg, int idx) {
-    throw new InvalidAccessExpressionException(msg, new String(expression, UTF_8), idx);
+    throw new IllegalAccessExpressionException(msg, new String(expression, UTF_8), idx);
   }
 
   byte peek() {

--- a/src/test/java/org/apache/accumulo/access/AccessEvaluatorTest.java
+++ b/src/test/java/org/apache/accumulo/access/AccessEvaluatorTest.java
@@ -146,21 +146,21 @@ public class AccessEvaluatorTest {
                 expression);
             break;
           case ERROR:
-            assertThrows(InvalidAccessExpressionException.class,
+            assertThrows(IllegalAccessExpressionException.class,
                 () -> evaluator.canAccess(expression), expression);
-            assertThrows(InvalidAccessExpressionException.class,
+            assertThrows(IllegalAccessExpressionException.class,
                 () -> evaluator.canAccess(expression.getBytes(UTF_8)), expression);
-            assertThrows(InvalidAccessExpressionException.class,
+            assertThrows(IllegalAccessExpressionException.class,
                 () -> AccessExpression.validate(expression), expression);
-            assertThrows(InvalidAccessExpressionException.class,
+            assertThrows(IllegalAccessExpressionException.class,
                 () -> AccessExpression.validate(expression.getBytes(UTF_8)), expression);
-            assertThrows(InvalidAccessExpressionException.class,
+            assertThrows(IllegalAccessExpressionException.class,
                 () -> AccessExpression.of(expression), expression);
-            assertThrows(InvalidAccessExpressionException.class,
+            assertThrows(IllegalAccessExpressionException.class,
                 () -> AccessExpression.of(expression.getBytes(UTF_8)), expression);
-            assertThrows(InvalidAccessExpressionException.class,
+            assertThrows(IllegalAccessExpressionException.class,
                 () -> AccessExpression.parse(expression), expression);
-            assertThrows(InvalidAccessExpressionException.class,
+            assertThrows(IllegalAccessExpressionException.class,
                 () -> AccessExpression.parse(expression.getBytes(UTF_8)), expression);
             break;
           default:

--- a/src/test/java/org/apache/accumulo/access/AccessExpressionTest.java
+++ b/src/test/java/org/apache/accumulo/access/AccessExpressionTest.java
@@ -86,7 +86,7 @@ public class AccessExpressionTest {
   }
 
   void checkError(Executable executable, String expected, int index) {
-    var exception = assertThrows(InvalidAccessExpressionException.class, executable);
+    var exception = assertThrows(IllegalAccessExpressionException.class, executable);
     assertTrue(exception.getMessage().contains(expected));
     assertEquals(index, exception.getIndex());
   }


### PR DESCRIPTION
Renamed InvalidAccessExpressionException to
IllegalAccessExpressionException because it extends IllegalArgumentException.  So now it uses the same terminology as its parent class.