### PR TITLE
Replace maven.multiModuleProjectDirectory with ".."

### DIFF
--- a/antlr4-example/pom.xml
+++ b/antlr4-example/pom.xml
@@ -108,7 +108,7 @@
               <outputDirectory>${project.basedir}/target/test-classes</outputDirectory>
               <resources>
                 <resource>
-                  <directory>${maven.multiModuleProjectDirectory}/core/src/main/resources/org/apache/accumulo/access/specification</directory>
+                  <directory>../core/src/main/resources/org/apache/accumulo/access/specification</directory>
                   <filtering>false</filtering>
                   <includes>
                     <include>AccessExpression.abnf</include>

--- a/pom.xml
+++ b/pom.xml
@@ -507,14 +507,14 @@
               <outputDirectory>${basedir}/target/test-classes</outputDirectory>
               <resources>
                 <resource>
-                  <directory>${maven.multiModuleProjectDirectory}</directory>
+                  <directory>..</directory>
                   <filtering>false</filtering>
                   <includes>
                     <include>SPECIFICATION.md</include>
                   </includes>
                 </resource>
                 <resource>
-                  <directory>${maven.multiModuleProjectDirectory}/src/test/resources</directory>
+                  <directory>../src/test/resources</directory>
                   <filtering>false</filtering>
                   <includes>
                     <include>testdata.json</include>


### PR DESCRIPTION
The poms were using maven.multiModuleProjectDirectory to get the parent directory in each module pom. This was working locally, but the builds on ci-builds.apache.org didn't like it for some reason. Removing the property and replacing with ".." to see if that will fix the issue.