### PR TITLE
Modified entry point for AccessEvaluator

### DIFF
--- a/antlr4-example/src/main/java/org/apache/accumulo/access/antlr4/AccessExpressionAntlrEvaluator.java
+++ b/antlr4-example/src/main/java/org/apache/accumulo/access/antlr4/AccessExpressionAntlrEvaluator.java
@@ -26,7 +26,6 @@ import java.util.Set;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.apache.accumulo.access.AccessExpression;
-import org.apache.accumulo.access.Authorizations;
 import org.apache.accumulo.access.InvalidAccessExpressionException;
 import org.apache.accumulo.access.grammars.AccessExpressionParser.Access_expressionContext;
 import org.apache.accumulo.access.grammars.AccessExpressionParser.Access_tokenContext;
@@ -34,6 +33,7 @@ import org.apache.accumulo.access.grammars.AccessExpressionParser.And_expression
 import org.apache.accumulo.access.grammars.AccessExpressionParser.And_operatorContext;
 import org.apache.accumulo.access.grammars.AccessExpressionParser.Or_expressionContext;
 import org.apache.accumulo.access.grammars.AccessExpressionParser.Or_operatorContext;
+import org.apache.accumulo.access.Authorizations;
 
 public class AccessExpressionAntlrEvaluator {
 

--- a/antlr4-example/src/test/java/org/apache/accumulo/access/grammar/antlr/AccessExpressionAntlrBenchmark.java
+++ b/antlr4-example/src/test/java/org/apache/accumulo/access/grammar/antlr/AccessExpressionAntlrBenchmark.java
@@ -29,11 +29,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.accumulo.access.Authorizations;
 import org.apache.accumulo.access.antlr.TestDataLoader;
 import org.apache.accumulo.access.antlr4.AccessExpressionAntlrEvaluator;
 import org.apache.accumulo.access.antlr4.AccessExpressionAntlrParser;
 import org.apache.accumulo.access.grammars.AccessExpressionParser.Access_expressionContext;
+import org.apache.accumulo.access.Authorizations;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Scope;

--- a/antlr4-example/src/test/java/org/apache/accumulo/access/grammar/antlr/Antlr4Tests.java
+++ b/antlr4-example/src/test/java/org/apache/accumulo/access/grammar/antlr/Antlr4Tests.java
@@ -41,7 +41,6 @@ import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
 import org.apache.accumulo.access.AccessEvaluator;
 import org.apache.accumulo.access.AccessExpression;
-import org.apache.accumulo.access.Authorizations;
 import org.apache.accumulo.access.InvalidAccessExpressionException;
 import org.apache.accumulo.access.antlr.TestDataLoader;
 import org.apache.accumulo.access.antlr.TestDataLoader.ExpectedResult;
@@ -51,6 +50,7 @@ import org.apache.accumulo.access.antlr4.AccessExpressionAntlrEvaluator;
 import org.apache.accumulo.access.grammars.AccessExpressionLexer;
 import org.apache.accumulo.access.grammars.AccessExpressionParser;
 import org.apache.accumulo.access.grammars.AccessExpressionParser.Access_expressionContext;
+import org.apache.accumulo.access.Authorizations;
 import org.junit.jupiter.api.Test;
 
 public class Antlr4Tests {
@@ -144,7 +144,7 @@ public class Antlr4Tests {
 
       List<Authorizations> authSets = Stream.of(testSet.auths)
           .map(a -> Authorizations.of(Set.of(a))).collect(Collectors.toList());
-      AccessEvaluator evaluator = AccessEvaluator.of(authSets);
+      AccessEvaluator evaluator = Authorizations.evaluator(authSets);
       AccessExpressionAntlrEvaluator antlr = new AccessExpressionAntlrEvaluator(authSets);
 
       for (TestExpressions test : testSet.tests) {

--- a/core/src/main/java/org/apache/accumulo/access/AccessEvaluator.java
+++ b/core/src/main/java/org/apache/accumulo/access/AccessEvaluator.java
@@ -18,8 +18,6 @@
  */
 package org.apache.accumulo.access;
 
-import java.util.Collection;
-
 import org.apache.accumulo.access.impl.AccessEvaluatorImpl;
 import org.apache.accumulo.access.impl.MultiAccessEvaluatorImpl;
 
@@ -32,7 +30,7 @@ import org.apache.accumulo.access.impl.MultiAccessEvaluatorImpl;
  *
  * <pre>
  * {@code
- * var evaluator = AccessEvaluator.of("ALPHA", "OMEGA");
+ * var evaluator = Authorizations.of(Set.of("ALPHA", "OMEGA")).evaluator();
  *
  * System.out.println(evaluator.canAccess("ALPHA&BETA")); // should print 'false'
  * System.out.println(evaluator.canAccess("(ALPHA|BETA)&(OMEGA|EPSILON)")); // should print 'true'
@@ -80,88 +78,4 @@ public sealed interface AccessEvaluator permits AccessEvaluatorImpl, MultiAccess
    */
   boolean canAccess(AccessExpression accessExpression);
 
-  /**
-   * Creates an AccessEvaluator from an Authorizations object
-   *
-   * @param authorizations auths to use in the AccessEvaluator
-   * @return AccessEvaluator object
-   */
-  static AccessEvaluator of(Authorizations authorizations) {
-    return new AccessEvaluatorImpl(authorizations);
-  }
-
-  /**
-   * Creates an AccessEvaluator from an Authorizer object
-   *
-   * @param authorizer authorizer to use in the AccessEvaluator
-   * @return AccessEvaluator object
-   */
-  static AccessEvaluator of(Authorizer authorizer) {
-    return new AccessEvaluatorImpl(authorizer);
-  }
-
-  /**
-   * Allows providing multiple sets of authorizations. Each expression will be evaluated
-   * independently against each set of authorizations and will only be deemed accessible if
-   * accessible for all. For example the following code would print false, true, and then false.
-   *
-   * <pre>
-   *     {@code
-   * Collection<Authorizations> authSets =
-   *     List.of(Authorizations.of("A", "B"), Authorizations.of("C", "D"));
-   * var evaluator = AccessEvaluator.of(authSets);
-   *
-   * System.out.println(evaluator.canAccess("A"));
-   * System.out.println(evaluator.canAccess("A|D"));
-   * System.out.println(evaluator.canAccess("A&D"));
-   *
-   * }
-   * </pre>
-   *
-   * <p>
-   * The following table shows how each expression in the example above will evaluate for each
-   * authorization set. In order to return true for {@code canAccess()} the expression must evaluate
-   * to true for each authorization set.
-   *
-   * <table>
-   * <caption>Evaluations</caption>
-   * <tr>
-   * <td></td>
-   * <td>[A,B]</td>
-   * <td>[C,D]</td>
-   * </tr>
-   * <tr>
-   * <td>A</td>
-   * <td>True</td>
-   * <td>False</td>
-   * </tr>
-   * <tr>
-   * <td>A|D</td>
-   * <td>True</td>
-   * <td>True</td>
-   * </tr>
-   * <tr>
-   * <td>A&amp;D</td>
-   * <td>False</td>
-   * <td>False</td>
-   * </tr>
-   *
-   * </table>
-   *
-   *
-   *
-   */
-  static AccessEvaluator of(Collection<Authorizations> authorizationSets) {
-    return MultiAccessEvaluatorImpl.of(authorizationSets);
-  }
-
-  /**
-   * An interface that is used to check if an authorization seen in an access expression is
-   * authorized.
-   *
-   * @since 1.0.0
-   */
-  interface Authorizer {
-    boolean isAuthorized(String auth);
-  }
 }

--- a/core/src/main/java/org/apache/accumulo/access/impl/AccessEvaluatorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/access/impl/AccessEvaluatorImpl.java
@@ -30,7 +30,7 @@ import java.util.function.Predicate;
 
 import org.apache.accumulo.access.AccessEvaluator;
 import org.apache.accumulo.access.AccessExpression;
-import org.apache.accumulo.access.Authorizations;
+import org.apache.accumulo.access.Authorizations.Authorizer;
 import org.apache.accumulo.access.InvalidAccessExpressionException;
 
 public final class AccessEvaluatorImpl implements AccessEvaluator {
@@ -47,7 +47,7 @@ public final class AccessEvaluatorImpl implements AccessEvaluator {
   /**
    * Create an AccessEvaluatorImpl using a collection of authorizations
    */
-  public AccessEvaluatorImpl(Authorizations authorizations) {
+  public AccessEvaluatorImpl(AuthorizationsImpl authorizations) {
     var authsSet = authorizations.asSet();
     final Set<BytesWrapper> authBytes = new HashSet<>(authsSet.size());
     for (String authorization : authsSet) {

--- a/core/src/main/java/org/apache/accumulo/access/impl/AuthorizationsImpl.java
+++ b/core/src/main/java/org/apache/accumulo/access/impl/AuthorizationsImpl.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.accumulo.access.impl;
+
+import java.util.Iterator;
+import java.util.Set;
+
+import org.apache.accumulo.access.AccessEvaluator;
+import org.apache.accumulo.access.Authorizations;
+
+/**
+ * An immutable collection of authorization strings.
+ *
+ * <p>
+ * Instances of this class are thread-safe.
+ *
+ * <p>
+ * Note: The underlying implementation uses UTF-8 when converting between bytes and Strings.
+ *
+ * @since 1.0.0
+ */
+public final class AuthorizationsImpl implements Authorizations {
+
+  private static final long serialVersionUID = 1L;
+
+  public static final AuthorizationsImpl EMPTY = new AuthorizationsImpl(Set.of());
+
+  private final Set<String> authorizations;
+
+  public AuthorizationsImpl(Set<String> authorizations) {
+    this.authorizations = Set.copyOf(authorizations);
+  }
+
+  public Set<String> asSet() {
+    return authorizations;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof AuthorizationsImpl) {
+      var oa = (AuthorizationsImpl) o;
+      return authorizations.equals(oa.authorizations);
+    }
+
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return authorizations.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return authorizations.toString();
+  }
+
+  @Override
+  public Iterator<String> iterator() {
+    return authorizations.iterator();
+  }
+
+  @Override
+  public AccessEvaluator evaluator() {
+    return new AccessEvaluatorImpl(this);
+  }
+
+}

--- a/core/src/main/java/org/apache/accumulo/access/impl/MultiAccessEvaluatorImpl.java
+++ b/core/src/main/java/org/apache/accumulo/access/impl/MultiAccessEvaluatorImpl.java
@@ -31,16 +31,12 @@ import org.apache.accumulo.access.InvalidAccessExpressionException;
 
 public final class MultiAccessEvaluatorImpl implements AccessEvaluator {
 
-  public static AccessEvaluator of(Collection<Authorizations> authorizationSets) {
-    return new MultiAccessEvaluatorImpl(authorizationSets);
-  }
-
   private final List<AccessEvaluator> evaluators;
 
-  private MultiAccessEvaluatorImpl(Collection<Authorizations> authorizationSets) {
+  public MultiAccessEvaluatorImpl(Collection<Authorizations> authorizationSets) {
     evaluators = new ArrayList<>(authorizationSets.size());
     for (Authorizations authorizations : authorizationSets) {
-      evaluators.add(new AccessEvaluatorImpl(authorizations));
+      evaluators.add(authorizations.evaluator());
     }
   }
 

--- a/core/src/test/java/org/apache/accumulo/access/tests/AccessEvaluatorTest.java
+++ b/core/src/test/java/org/apache/accumulo/access/tests/AccessEvaluatorTest.java
@@ -90,16 +90,16 @@ public class AccessEvaluatorTest {
       AccessEvaluator evaluator;
       assertTrue(testSet.auths.length >= 1);
       if (testSet.auths.length == 1) {
-        evaluator = AccessEvaluator.of(Authorizations.of(Set.of(testSet.auths[0])));
+        evaluator = Authorizations.of(Set.of(testSet.auths[0])).evaluator();
         runTestCases(testSet, evaluator);
 
         Set<String> auths = Stream.of(testSet.auths[0]).collect(Collectors.toSet());
-        evaluator = AccessEvaluator.of(auths::contains);
+        evaluator = Authorizations.using(auths::contains);
         runTestCases(testSet, evaluator);
       } else {
         var authSets = Stream.of(testSet.auths).map(a -> Authorizations.of(Set.of(a)))
             .collect(Collectors.toList());
-        evaluator = AccessEvaluator.of(authSets);
+        evaluator = Authorizations.evaluator(authSets);
         runTestCases(testSet, evaluator);
       }
     }
@@ -176,14 +176,12 @@ public class AccessEvaluatorTest {
 
   @Test
   public void testEmptyAuthorizations() {
+    assertThrows(IllegalArgumentException.class, () -> Authorizations.of(Set.of("")).evaluator());
     assertThrows(IllegalArgumentException.class,
-        () -> AccessEvaluator.of(Authorizations.of(Set.of(""))));
+        () -> Authorizations.of(Set.of("", "A")).evaluator());
     assertThrows(IllegalArgumentException.class,
-        () -> AccessEvaluator.of(Authorizations.of(Set.of("", "A"))));
-    assertThrows(IllegalArgumentException.class,
-        () -> AccessEvaluator.of(Authorizations.of(Set.of("A", ""))));
-    assertThrows(IllegalArgumentException.class,
-        () -> AccessEvaluator.of(Authorizations.of(Set.of(""))));
+        () -> Authorizations.of(Set.of("A", "")).evaluator());
+    assertThrows(IllegalArgumentException.class, () -> Authorizations.of(Set.of("")).evaluator());
   }
 
   @Test

--- a/core/src/test/java/org/apache/accumulo/access/tests/AccessExpressionBenchmark.java
+++ b/core/src/test/java/org/apache/accumulo/access/tests/AccessExpressionBenchmark.java
@@ -119,11 +119,11 @@ public class AccessExpressionBenchmark {
         et.expressions = new ArrayList<>();
 
         if (testDataSet.auths.length == 1) {
-          et.evaluator = AccessEvaluator.of(Authorizations.of(Set.of(testDataSet.auths[0])));
+          et.evaluator = Authorizations.of(Set.of(testDataSet.auths[0])).evaluator();
         } else {
           var authSets = Stream.of(testDataSet.auths).map(a -> Authorizations.of(Set.of(a)))
               .collect(Collectors.toList());
-          et.evaluator = AccessEvaluator.of(authSets);
+          et.evaluator = Authorizations.evaluator(authSets);
         }
 
         for (var tests : testDataSet.tests) {

--- a/examples/src/main/java/org/apache/accumulo/access/examples/AccessExample.java
+++ b/examples/src/main/java/org/apache/accumulo/access/examples/AccessExample.java
@@ -53,7 +53,7 @@ public class AccessExample {
         Arrays.toString(authorizations));
 
     // Create an access evaluator using the provided authorizations
-    AccessEvaluator evaluator = AccessEvaluator.of(Authorizations.of(Set.of(authorizations)));
+    AccessEvaluator evaluator = Authorizations.of(Set.of(authorizations)).evaluator();
 
     // Print each record whose access expression permits viewing using the provided authorizations
     getData().forEach((record, accessExpression) -> {


### PR DESCRIPTION
Removed the 'of' methods from the AccessEvaluator
interface. Created an interface for Authorizations and renamed the current class to AuthorizationsImpl. Added the following methods to get an AccessEvaluator:

  1. The evaluator() method on an Authorizations instance
  2. The Authorizations.evalutor() static method to get an instance for multiple Authorizations objects.
  3. The Authorizations.using(Authorizor) static method.

Closes #56