### PR TITLE
Support a java-11 compile target

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ are package private and are not part of the public API.
   * [ExpressionType](modules/core/src/main/java/org/apache/accumulo/access/ParsedAccessExpression.java).
   * [Authorizations](modules/core/src/main/java/org/apache/accumulo/access/Authorizations.java).
 
+`AccessEvaluator`, `AccessExpression`, and `ParsedAccessExpression` will be
+sealed interfaces or classes in future releases that support class sealing. So,
+users should not create their own implementations of these. Their
+implementations are expected to be provided by this library only.
+
 ## Getting Started
 
 Add the library to your CLASSPATH. For Maven, use:

--- a/modules/antlr4-example/src/test/java/org/apache/accumulo/access/antlr4/Antlr4Tests.java
+++ b/modules/antlr4-example/src/test/java/org/apache/accumulo/access/antlr4/Antlr4Tests.java
@@ -152,20 +152,20 @@ class Antlr4Tests {
         assertNotEquals(0, test.getExpressions().length);
         for (String expression : test.getExpressions()) {
           switch (test.getExpectedResult()) {
-            case ACCESSIBLE -> {
+            case ACCESSIBLE:
               assertTrue(evaluator.canAccess(expression), expression);
               assertTrue(antlr.canAccess(expression), expression);
-            }
-            case INACCESSIBLE -> {
+              break;
+            case INACCESSIBLE:
               assertFalse(evaluator.canAccess(expression), expression);
               assertFalse(antlr.canAccess(expression), expression);
-            }
-            case ERROR -> {
+              break;
+            case ERROR:
               assertThrows(InvalidAccessExpressionException.class,
                   () -> evaluator.canAccess(expression), expression);
               assertThrows(InvalidAccessExpressionException.class,
                   () -> antlr.canAccess(expression), expression);
-            }
+              break;
           }
         }
       }

--- a/modules/core/src/main/java/org/apache/accumulo/access/AccessEvaluator.java
+++ b/modules/core/src/main/java/org/apache/accumulo/access/AccessEvaluator.java
@@ -18,9 +18,6 @@
  */
 package org.apache.accumulo.access;
 
-import org.apache.accumulo.access.impl.AccessEvaluatorImpl;
-import org.apache.accumulo.access.impl.MultiAccessEvaluatorImpl;
-
 /**
  * This class is used to decide if an entity with a given set of authorizations can access
  * subsequent access expressions.
@@ -53,7 +50,7 @@ import org.apache.accumulo.access.impl.MultiAccessEvaluatorImpl;
  * @see <a href="https://github.com/apache/accumulo-access">Accumulo Access Documentation</a>
  * @since 1.0.0
  */
-public sealed interface AccessEvaluator permits AccessEvaluatorImpl, MultiAccessEvaluatorImpl {
+public interface AccessEvaluator {
 
   /**
    * Evaluates an expression.

--- a/modules/core/src/main/java/org/apache/accumulo/access/AccessExpression.java
+++ b/modules/core/src/main/java/org/apache/accumulo/access/AccessExpression.java
@@ -21,15 +21,12 @@ package org.apache.accumulo.access;
 import java.io.Serializable;
 import java.util.Objects;
 
-import org.apache.accumulo.access.impl.AccessExpressionImpl;
-
 /**
  * An immutable wrapper for a validated access expression.
  *
  * @since 1.0.0
  */
-public sealed abstract class AccessExpression implements Serializable
-    permits AccessExpressionImpl, ParsedAccessExpression {
+public abstract class AccessExpression implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
@@ -53,8 +50,8 @@ public sealed abstract class AccessExpression implements Serializable
 
   @Override
   public boolean equals(Object o) {
-    return this == o
-        || (o instanceof AccessExpression a && Objects.equals(getExpression(), a.getExpression()));
+    return this == o || (o instanceof AccessExpression
+        && Objects.equals(getExpression(), ((AccessExpression) o).getExpression()));
   }
 
   @Override

--- a/modules/core/src/main/java/org/apache/accumulo/access/ParsedAccessExpression.java
+++ b/modules/core/src/main/java/org/apache/accumulo/access/ParsedAccessExpression.java
@@ -20,8 +20,6 @@ package org.apache.accumulo.access;
 
 import java.util.List;
 
-import org.apache.accumulo.access.impl.ParsedAccessExpressionImpl;
-
 /**
  * Instances of this class are immutable and wrap a verified access expression and a parse tree for
  * the access expression. To create an instance of this class call
@@ -30,8 +28,7 @@ import org.apache.accumulo.access.impl.ParsedAccessExpressionImpl;
  *
  * @since 1.0.0
  */
-public sealed abstract class ParsedAccessExpression extends AccessExpression
-    permits ParsedAccessExpressionImpl {
+public abstract class ParsedAccessExpression extends AccessExpression {
 
   private static final long serialVersionUID = 1L;
 

--- a/modules/core/src/main/java/org/apache/accumulo/access/impl/AccessEvaluatorImpl.java
+++ b/modules/core/src/main/java/org/apache/accumulo/access/impl/AccessEvaluatorImpl.java
@@ -52,7 +52,7 @@ public final class AccessEvaluatorImpl implements AccessEvaluator {
         .andThen(auth -> wrappedAuths.add(new CharsWrapper(auth.toCharArray()))));
 
     this.authorizedPredicate =
-        auth -> auth instanceof CharsWrapper wrapped ? wrappedAuths.contains(wrapped)
+        auth -> auth instanceof CharsWrapper ? wrappedAuths.contains((CharsWrapper) auth)
             : wrappedAuths.contains(new CharsWrapper(auth.toString().toCharArray()));
     this.authorizationValidator = authorizationValidator;
   }

--- a/modules/core/src/main/java/org/apache/accumulo/access/impl/AccessImpl.java
+++ b/modules/core/src/main/java/org/apache/accumulo/access/impl/AccessImpl.java
@@ -40,7 +40,7 @@ public class AccessImpl implements Access {
   private final AuthorizationValidator authValidator;
 
   private void validateAuthArgument(CharSequence auth) {
-    if (auth.isEmpty()) {
+    if (auth.length() == 0) {
       throw InvalidAuthorizationException.emptyString();
     }
     if (!authValidator.test(auth, ANY)) {

--- a/modules/core/src/main/java/org/apache/accumulo/access/impl/CharsWrapper.java
+++ b/modules/core/src/main/java/org/apache/accumulo/access/impl/CharsWrapper.java
@@ -69,8 +69,9 @@ final class CharsWrapper implements CharSequence {
 
   @Override
   public boolean equals(Object o) {
-    return this == o || (o instanceof CharsWrapper obs && length() == obs.length() && Arrays
-        .equals(wrapped, offset, offset + len, obs.wrapped, obs.offset, obs.offset + obs.len));
+    return this == o || (o instanceof CharsWrapper && length() == ((CharsWrapper) o).length()
+        && Arrays.equals(wrapped, offset, offset + len, ((CharsWrapper) o).wrapped,
+            ((CharsWrapper) o).offset, ((CharsWrapper) o).offset + ((CharsWrapper) o).len));
   }
 
   @Override

--- a/modules/core/src/test/java/org/apache/accumulo/access/impl/AccessEvaluatorTest.java
+++ b/modules/core/src/test/java/org/apache/accumulo/access/impl/AccessEvaluatorTest.java
@@ -93,7 +93,7 @@ class AccessEvaluatorTest {
         }
 
         switch (tests.getExpectedResult()) {
-          case ACCESSIBLE -> {
+          case ACCESSIBLE:
             assertTrue(evaluator.canAccess(expression), expression);
             assertTrue(evaluator.canAccess(accumuloAccess.newExpression(expression)), expression);
             assertTrue(evaluator.canAccess(accumuloAccess.newParsedExpression(expression)),
@@ -101,8 +101,8 @@ class AccessEvaluatorTest {
             assertTrue(
                 evaluator.canAccess(accumuloAccess.newParsedExpression(expression).getExpression()),
                 expression);
-          }
-          case INACCESSIBLE -> {
+            break;
+          case INACCESSIBLE:
             assertFalse(evaluator.canAccess(expression), expression);
             assertFalse(evaluator.canAccess(accumuloAccess.newExpression(expression)), expression);
             assertFalse(evaluator.canAccess(accumuloAccess.newParsedExpression(expression)),
@@ -110,8 +110,8 @@ class AccessEvaluatorTest {
             assertFalse(
                 evaluator.canAccess(accumuloAccess.newParsedExpression(expression).getExpression()),
                 expression);
-          }
-          case ERROR -> {
+            break;
+          case ERROR:
             assertThrows(InvalidAccessExpressionException.class,
                 () -> evaluator.canAccess(expression), expression);
             assertThrows(InvalidAccessExpressionException.class,
@@ -120,7 +120,7 @@ class AccessEvaluatorTest {
                 () -> accumuloAccess.newExpression(expression), expression);
             assertThrows(InvalidAccessExpressionException.class,
                 () -> accumuloAccess.newParsedExpression(expression), expression);
-          }
+            break;
         }
       }
     }

--- a/modules/examples/src/main/java/org/apache/accumulo/access/examples/ParseExamples.java
+++ b/modules/examples/src/main/java/org/apache/accumulo/access/examples/ParseExamples.java
@@ -85,12 +85,17 @@ public class ParseExamples {
 
     // determines the sort order of different kinds of subexpressions.
     private static int typeOrder(ExpressionType type) {
-      return switch (type) {
-        case AUTHORIZATION -> 1;
-        case OR -> 2;
-        case AND -> 3;
-        case EMPTY -> throw new IllegalArgumentException("Unexpected type " + type);
-      };
+      switch (type) {
+        case AUTHORIZATION:
+          return 1;
+        case OR:
+          return 2;
+        case AND:
+          return 3;
+        case EMPTY:
+        default:
+          throw new IllegalArgumentException("Unexpected type " + type);
+      }
     }
 
     @Override
@@ -111,7 +116,8 @@ public class ParseExamples {
 
     @Override
     public boolean equals(Object o) {
-      return this == o || (o instanceof NormalizedExpression n && compareTo(n) == 0);
+      return this == o
+          || (o instanceof NormalizedExpression && compareTo((NormalizedExpression) o) == 0);
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@ under the License.
     <rat.consoleOutput>true</rat.consoleOutput>
     <sourceReleaseAssemblyDescriptor>source-release-tar</sourceReleaseAssemblyDescriptor>
     <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
-    <version.accumulo>2.1.4</version.accumulo>
+    <version.accumulo>3.0.0</version.accumulo>
     <version.apache-rat-plugin>0.18</version.apache-rat-plugin>
     <version.errorprone>2.47.0</version.errorprone>
     <version.gson>2.13.2</version.gson>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@ specific language governing permissions and limitations
 under the License.
 ]]></accumulo.build.license.header>
     <failsafe.failIfNoSpecifiedTests>false</failsafe.failIfNoSpecifiedTests>
-    <javaVersion>17</javaVersion>
+    <javaVersion>11</javaVersion>
     <!-- prevent introduction of new compiler warnings -->
     <maven.compiler.failOnWarning>true</maven.compiler.failOnWarning>
     <maven.javadoc.failOnWarnings>true</maven.javadoc.failOnWarnings>
@@ -134,7 +134,7 @@ under the License.
     <rat.consoleOutput>true</rat.consoleOutput>
     <sourceReleaseAssemblyDescriptor>source-release-tar</sourceReleaseAssemblyDescriptor>
     <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
-    <version.accumulo>3.0.0</version.accumulo>
+    <version.accumulo>2.1.4</version.accumulo>
     <version.apache-rat-plugin>0.18</version.apache-rat-plugin>
     <version.errorprone>2.47.0</version.errorprone>
     <version.gson>2.13.2</version.gson>


### PR DESCRIPTION
Users looking to migrate away from ColumnVisibility class usage in accumulo 2.1.x need a version of accumulo-access that supports java-11.

The dependency target was also changed from 3.0.0 to 2.1.4 to ensure users have a supported migration path.